### PR TITLE
Upgrade to Tokio v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ maintenance = { status = "passively-maintained" }
 futures-core = "0.3.0"
 futures-util = "0.3.0"
 pin-project = "0.4.0"
-tokio = { version = "0.2.0", features = ["sync", "io-util"] }
+tokio = { version = "0.3.0", features = ["sync", "io-util"] }
 
 [dev-dependencies]
 futures = "0.3.0"
-tokio = { version = "0.2.0", features = ["full"] }
+tokio = { version = "0.3.0", features = ["full"] }

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::sync::watch;
+use tokio::pin;
 
 /// A stream combinator which takes elements from a stream until a future resolves.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!     let (trigger, tripwire) = Tripwire::new();
 //!
 //!     tokio::spawn(async move {
-//!         let mut incoming = listener.incoming().take_until_if(tripwire);
+//!         let mut incoming = listener.take_until_if(tripwire);
 //!         while let Some(mut s) = incoming.next().await.transpose().unwrap() {
 //!             tokio::spawn(async move {
 //!                 let (mut r, mut w) = s.split();
@@ -57,7 +57,7 @@
 //!     let mut listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
 //!
 //!     tokio::spawn(async move {
-//!         let (exit, mut incoming) = Valved::new(listener.incoming());
+//!         let (exit, mut incoming) = Valved::new(listener);
 //!         exit_tx.send(exit).unwrap();
 //!         while let Some(mut s) = incoming.next().await.transpose().unwrap() {
 //!             tokio::spawn(async move {
@@ -91,8 +91,8 @@
 //!     let mut listener2 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
 //!
 //!     tokio::spawn(async move {
-//!         let incoming1 = valve.wrap(listener1.incoming());
-//!         let incoming2 = valve.wrap(listener2.incoming());
+//!         let incoming1 = valve.wrap(listener1);
+//!         let incoming2 = valve.wrap(listener2);
 //!
 //!         use futures_util::stream::select;
 //!         let mut incoming = select(incoming1, incoming2);
@@ -147,7 +147,7 @@ impl Drop for Trigger {
         if let Some(tx) = self.0.take() {
             // Send may fail when all associated rx'es are dropped already
             // so code here cannot panic on error
-            let _ = tx.broadcast(true);
+            let _ = tx.send(true);
         }
     }
 }
@@ -163,8 +163,8 @@ mod tests {
     fn tokio_run() {
         use std::thread;
 
-        let mut rt = tokio::runtime::Runtime::new().unwrap();
-        let mut listener = rt
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let listener = rt
             .block_on(tokio::net::TcpListener::bind("0.0.0.0:0"))
             .unwrap();
         let (exit_tx, exit_rx) = tokio::sync::oneshot::channel();
@@ -173,7 +173,7 @@ mod tests {
 
             // start a tokio echo server
             rt.block_on(async move {
-                let (exit, mut incoming) = Valved::new(listener.incoming());
+                let (exit, mut incoming) = Valved::new(listener);
                 exit_tx.send(exit).unwrap();
                 while let Some(mut s) = incoming.next().await.transpose().unwrap() {
                     tokio::spawn(async move {
@@ -200,8 +200,8 @@ mod tests {
         let (exit_tx, exit_rx) = tokio::sync::oneshot::channel();
 
         tokio::spawn(async move {
-            let mut listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
-            let (exit, mut incoming) = Valved::new(listener.incoming());
+            let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+            let (exit, mut incoming) = Valved::new(listener);
             exit_tx.send(exit).unwrap();
             while let Some(mut s) = incoming.next().await.transpose().unwrap() {
                 tokio::spawn(async move {
@@ -219,10 +219,10 @@ mod tests {
     async fn multi_interrupt() {
         let (exit, valve) = Valve::new();
         tokio::spawn(async move {
-            let mut listener1 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
-            let mut listener2 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
-            let incoming1 = valve.wrap(listener1.incoming());
-            let incoming2 = valve.wrap(listener2.incoming());
+            let listener1 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+            let listener2 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+            let incoming1 = valve.wrap(listener1);
+            let incoming2 = valve.wrap(listener2);
 
             let mut incoming = select(incoming1, incoming2);
             while let Some(mut s) = incoming.next().await.transpose().unwrap() {
@@ -246,13 +246,13 @@ mod tests {
         };
 
         let (exit, valve) = Valve::new();
-        let mut listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         let reqs = Arc::new(AtomicUsize::new(0));
         let got = reqs.clone();
         tokio::spawn(async move {
-            let mut incoming = valve.wrap(listener.incoming());
+            let mut incoming = valve.wrap(listener);
             while let Some(mut s) = incoming.next().await.transpose().unwrap() {
                 reqs.fetch_add(1, Ordering::SeqCst);
                 tokio::spawn(async move {
@@ -289,8 +289,8 @@ mod tests {
         };
 
         let (exit, valve) = Valve::new();
-        let mut listener1 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
-        let mut listener2 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let listener1 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let listener2 = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
         let addr1 = listener1.local_addr().unwrap();
         let addr2 = listener2.local_addr().unwrap();
 
@@ -298,8 +298,8 @@ mod tests {
         let got = reqs.clone();
 
         tokio::spawn(async move {
-            let incoming1 = valve.wrap(listener1.incoming());
-            let incoming2 = valve.wrap(listener2.incoming());
+            let incoming1 = valve.wrap(listener1);
+            let incoming2 = valve.wrap(listener2);
             let mut incoming = select(incoming1, incoming2);
             while let Some(mut s) = incoming.next().await.transpose().unwrap() {
                 reqs.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
👋 hey @jonhoo! Unfortunately this doesn't actually work yet, since Tokio v0.3 reworks the watch receiver API in a way that makes it really hard to keep the existing stream-cancel API. I'm going to see if I can fix this upstream.