### PR TITLE
Upgrade to tokio 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 futures-core = "0.3.0"
 futures-util = "0.3.0"
-pin-project = "0.4.0"
+pin-project = "1.0.0"
 tokio = { version = "0.3.0", features = ["sync", "io-util"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ maintenance = { status = "passively-maintained" }
 futures-core = "0.3.0"
 futures-util = "0.3.0"
 pin-project = "0.4.0"
-tokio = { version = "0.2.0", features = ["sync", "io-util"] }
+tokio = { version = "0.3.0", features = ["sync", "io-util"] }
 
 [dev-dependencies]
 futures = "0.3.0"
-tokio = { version = "0.2.0", features = ["full"] }
+tokio = { version = "0.3.0", features = ["full"] }


### PR DESCRIPTION
The `Box` is a little unfortunate, but I don't know of a way to work around it without existential types ([`type_alias_impl_trait`](https://github.com/rust-lang/rust/issues/63063)). Luckily it's a change that can happen eventually behind the scenes.

Replaces and closes #7.