### PR TITLE
update to tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ license = "MIT/Apache-2.0"
 futures-core = "0.3.0"
 futures-util = "0.3.0"
 pin-project = "1.0.0"
-tokio1 = { package = "tokio", version = "1.0", features = ["sync"] }
+tokio = { version = "1.0", features = ["sync"] }
 
 [dev-dependencies]
 futures = "0.3.0"
-tokio = { package = "tokio", version = "0.3.0", features = ["full"] }
+tokio03 = { package = "tokio", version = "0.3.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ tokio = { version = "1.0", features = ["sync"] }
 
 [dev-dependencies]
 futures = "0.3.0"
-tokio03 = { package = "tokio", version = "0.3.0", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }
+tokio-stream = {version="0.1.1", features=["net"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ license = "MIT/Apache-2.0"
 futures-core = "0.3.0"
 futures-util = "0.3.0"
 pin-project = "1.0.0"
-tokio = { version = "0.3.0", features = ["sync", "io-util"] }
+tokio1 = { package = "tokio", version = "1.0", features = ["sync"] }
 
 [dev-dependencies]
 futures = "0.3.0"
-tokio = { version = "0.3.0", features = ["full"] }
+tokio = { package = "tokio", version = "0.3.0", features = ["full"] }

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -36,8 +36,7 @@ pub trait StreamExt: Stream {
     /// ```
     /// use stream_cancel::StreamExt;
     /// use futures::prelude::*;
-    /// use tokio03::prelude::*;
-    /// use tokio03 as tokio;
+    /// use tokio_stream::wrappers::TcpListenerStream;
     ///
     /// #[tokio::main]
     /// async fn main() {
@@ -45,7 +44,7 @@ pub trait StreamExt: Stream {
     ///     let (tx, rx) = tokio::sync::oneshot::channel();
     ///
     ///     tokio::spawn(async move {
-    ///         let mut incoming = listener.take_until_if(rx.map(|_| true));
+    ///         let mut incoming = TcpListenerStream::new(listener).take_until_if(rx.map(|_| true));
     ///         while let Some(mut s) = incoming.next().await.transpose().unwrap() {
     ///             tokio::spawn(async move {
     ///                 let (mut r, mut w) = s.split();

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::sync::watch;
+use tokio1::sync::watch;
 
 /// A stream combinator which takes elements from a stream until a future resolves.
 ///

--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio1::sync::watch;
+use tokio::sync::watch;
 
 /// A stream combinator which takes elements from a stream until a future resolves.
 ///
@@ -36,7 +36,8 @@ pub trait StreamExt: Stream {
     /// ```
     /// use stream_cancel::StreamExt;
     /// use futures::prelude::*;
-    /// use tokio::prelude::*;
+    /// use tokio03::prelude::*;
+    /// use tokio03 as tokio;
     ///
     /// #[tokio::main]
     /// async fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 //! `Future` that can then be passed to `take_until_if`. When a new `Tripwire` is created, an
 //! associated [`Trigger`] is also returned, which interrupts the `Stream` when it is dropped.
 //!
+//! Note that these examples use tokio 0.3 (not tokio 1.0) because [`Stream` has been temporarily
+//! removed from tokio 1.0](https://github.com/tokio-rs/tokio/issues/2870).
 //!
 //! ```
 //! use stream_cancel::{StreamExt, Tripwire};
@@ -114,7 +116,7 @@
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 
-use tokio::sync::watch;
+use tokio1::sync::watch;
 
 mod combinator;
 mod wrapper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,13 @@
 //! associated [`Trigger`] is also returned, which interrupts the `Stream` when it is dropped.
 //!
 //! Note that these examples use tokio 0.3 (not tokio 1.0) because [`Stream` has been temporarily
-//! removed from tokio 1.0](https://github.com/tokio-rs/tokio/issues/2870).
+//! removed from tokio 1.0](https://github.com/tokio03-rs/tokio03/issues/2870).
 //!
 //! ```
 //! use stream_cancel::{StreamExt, Tripwire};
 //! use futures::prelude::*;
-//! use tokio::prelude::*;
+//! use tokio03::prelude::*;
+//! use tokio03 as tokio;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -50,8 +51,9 @@
 //! ```
 //! use stream_cancel::Valved;
 //! use futures::prelude::*;
-//! use tokio::prelude::*;
+//! use tokio03::prelude::*;
 //! use std::thread;
+//! use tokio03 as tokio;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -84,7 +86,8 @@
 //! ```
 //! use stream_cancel::Valve;
 //! use futures::prelude::*;
-//! use tokio::prelude::*;
+//! use tokio03::prelude::*;
+//! use tokio03 as tokio;
 //!
 //! #[tokio::main]
 //! async fn main() {
@@ -116,7 +119,7 @@
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 
-use tokio1::sync::watch;
+use tokio::sync::watch;
 
 mod combinator;
 mod wrapper;
@@ -159,7 +162,8 @@ mod tests {
     use super::*;
     use futures::prelude::*;
     use futures_util::stream::select;
-    use tokio::prelude::*;
+    use tokio03 as tokio;
+    use tokio03::prelude::*;
 
     #[test]
     fn tokio_run() {


### PR DESCRIPTION
This updates the internal use of tokio to 1.0. As I note in the module-level docstring, the examples (and tests) are kept using tokio 0.3 because tokio itself has removed the Stream trait until it is added in std.

I don't think this is a breaking change because tokio is not part of the API. Thus, I believe this could be released as non-breaking semver version bump.