### PR TITLE
Add into_inner() function on stream combinators

### DIFF
--- a/src/combinator.rs
+++ b/src/combinator.rs
@@ -20,6 +20,13 @@ pub struct TakeUntilIf<S, F> {
     free: bool,
 }
 
+impl<S, F> TakeUntilIf<S, F> {
+    /// Consumes this combinator, returning the underlying stream.
+    pub fn into_inner(self) -> S {
+        self.stream
+    }
+}
+
 /// This `Stream` extension trait provides a `take_until_if` method that terminates the stream once
 /// the given future resolves.
 pub trait StreamExt: Stream {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -57,6 +57,11 @@ impl<S> Valved<S> {
         let (vh, v) = Valve::new();
         (vh, v.wrap(stream))
     }
+
+    /// Consumes this wrapper, returning the underlying stream.
+    pub fn into_inner(self) -> S {
+        self.0.into_inner()
+    }
 }
 
 impl<S> Stream for Valved<S>


### PR DESCRIPTION
Stream combinators like `map()` provide an `into_inner()` function that
allows obtaining the source stream. Add the same functionality for
`Valved` and `TakeUntilIf`.

This is useful when the source stream implements other functions; a
common case are functions meant to be called when the stream is
exhausted.
